### PR TITLE
Publish sample report using Github Pages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,3 @@
-#  
-
 name: Deploy sample report to Github Pages
 
 on:
@@ -42,9 +40,11 @@ jobs:
 
       - name: Generate sample report
         run: |
-          echo Generate overview report using .env.template variables
+          echo "Generate overview report using .env.template variables"
           export $(grep -v '^#' .template.env | xargs)
-          python -m investd report
+          report_path=$(python -m investd report)
+          echo "Rename report file to index.html"
+          mv $report_path "$(dirname $report_path)/index.html"
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,56 @@
+#  
+
+name: Deploy sample report to Github Pages
+
+on:
+  push:
+    branches: ["main", "41-publish-sample-report"]
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.11
+
+      - name: Install depedencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .
+
+      - name: Generate sample report
+        run: |
+          echo Generate overview report using .env.template variables
+          export $(grep -v '^#' .template.env | xargs)
+          python -m investd report
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: 'sample_data/reports/'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Deploy sample report to Github Pages
 
 on:
   push:
-    branches: ["main", "41-publish-sample-report"]
+    branches: ["main"]
 
   workflow_dispatch:
 

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 Tool for generating financial reports. Download statements from your broker or investment accounts, ingest them using investd and generate nice reports.
 
-Check the sample report generated from sample data at: http://adri0.github.io/investd
+Check out the sample report generated from sample data at: http://adri0.github.io/investd

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # investd
 
 Tool for generating financial reports. Download statements from your broker or investment accounts, ingest them using investd and generate nice reports.
+
+Check the sample report generated from sample data at: http://adri0.github.io/investd

--- a/investd/__main__.py
+++ b/investd/__main__.py
@@ -43,6 +43,7 @@ def report_cmd(report: str, ingest: bool):
         df_tx.to_csv(PERSIST_PATH / "tx.csv", index=False)
     path_output = reports.generate_report(report)
     log.info(f"Report created: {path_output}")
+    print(path_output)
 
 
 cli = click.Group(


### PR DESCRIPTION
- Add a workflow for generating `overview` report using the data in `sample_data` and publish it to [adri0.github.io/investd](adri0.github.io/investd) using Github Pages whenever a merge to main occurs.
- Closes #41 