### PR TITLE
Graceful failure if no transactions available for generating report

### DIFF
--- a/investd/__main__.py
+++ b/investd/__main__.py
@@ -7,7 +7,7 @@ from typing import Optional
 import click
 
 from investd import config, quotes, reports, sources
-from investd.errors import InvestdError
+from investd.exceptions import InvestdException
 from investd.transaction import TX_FILENAME
 
 APP_NAME = "investd"
@@ -89,7 +89,7 @@ def main() -> None:
     init_dirs()
     try:
         cli()
-    except InvestdError as exc:
+    except InvestdException as exc:
         log.error(exc.msg, exc_info=True)
         click.echo(exc.msg)
         exit(1)

--- a/investd/__main__.py
+++ b/investd/__main__.py
@@ -1,13 +1,13 @@
+import datetime
 import logging
 import os
-from datetime import date
 from pathlib import Path
 from typing import Optional
 
 import click
 
-from investd import quotes, reports, sources
-from investd.config import INVESTD_PERSIST, init_dirs
+from investd import config, quotes, reports, sources
+from investd.errors import InvestdError
 from investd.transaction import TX_FILENAME
 
 APP_NAME = "investd"
@@ -32,13 +32,11 @@ cli = click.Group(name=APP_NAME, help=HELP_TEXT)
 @click.option(
     "--output",
     type=click.Path(dir_okay=False, writable=True),
-    default=INVESTD_PERSIST / TX_FILENAME,
+    default=config.INVESTD_PERSIST / TX_FILENAME,
     help="Output path",
 )
 def ingest_sources_cmd(output: Path):
-    df_tx = sources.ingest_all()
-    log.info(f"Writing {output}")
-    df_tx.to_csv(output, index=False)
+    sources.ingest_to_path(output)
 
 
 @cli.command(name="report")
@@ -62,9 +60,8 @@ def ingest_sources_cmd(output: Path):
 )
 def report_cmd(report: str, ingest: bool, date: Optional[str]):
     if ingest:
-        df_tx = sources.ingest_all()
-        df_tx.to_csv(INVESTD_PERSIST / TX_FILENAME, index=False)
-    os.environ["REPORT_DATE"] = date
+        sources.ingest_to_path()
+    os.environ["REPORT_DATE"] = date or str(datetime.date.today())
     path_output = reports.generate_report(report)
     log.info(f"Report created: {path_output}")
     print(path_output)
@@ -81,8 +78,8 @@ def report_cmd(report: str, ingest: bool, date: Optional[str]):
 @click.option("--symbols", "-y", default=None, help="Symbols e.g. AAPL,CDR.PL")
 def quotes_cmd(start: Optional[str], end: Optional[str], symbols: Optional[str]):
     quotes.download_quotes_to_csv(
-        start_date=date.fromisoformat(start) if start else None,
-        end_date=date.fromisoformat(end) if end else None,
+        start_date=datetime.date.fromisoformat(start) if start else None,
+        end_date=datetime.date.fromisoformat(end) if end else None,
         symbols=symbols.split(",") if symbols else None,
         include_exchange_rates=True,
     )
@@ -90,7 +87,12 @@ def quotes_cmd(start: Optional[str], end: Optional[str], symbols: Optional[str])
 
 def main() -> None:
     init_dirs()
-    cli()
+    try:
+        cli()
+    except InvestdError as exc:
+        log.error(exc.msg, exc_info=True)
+        click.echo(exc.msg)
+        exit(1)
 
 
 if __name__ == "__main__":

--- a/investd/config.py
+++ b/investd/config.py
@@ -42,5 +42,4 @@ def init_dirs() -> None:
             f"INVESTD_DATA directory ({INVESTD_DATA}) doesn't exist. "
             "Let me create it for you."
         )
-    for conf_path in (INVESTD_SOURCES, INVESTD_PERSIST, INVESTD_REPORTS):
-        conf_path.mkdir(exist_ok=True)
+        INVESTD_DATA.mkdir(exist_ok=True, parents=True)

--- a/investd/errors.py
+++ b/investd/errors.py
@@ -1,7 +1,0 @@
-class InvestdError(Exception):
-    msg: str
-    pass
-
-
-class NoTransactions(InvestdError):
-    msg = "No transactions! Make sure you non-empty files in the sources folder according to each source."

--- a/investd/errors.py
+++ b/investd/errors.py
@@ -1,0 +1,7 @@
+class InvestdError(Exception):
+    msg: str
+    pass
+
+
+class NoTransactions(InvestdError):
+    msg = "No transactions! Make sure you non-empty files in the sources folder according to each source."

--- a/investd/exceptions.py
+++ b/investd/exceptions.py
@@ -1,0 +1,6 @@
+class InvestdException(Exception):
+    msg: str
+
+
+class NoTransactions(InvestdException):
+    msg = "No transactions! Make sure you have non-empty files in the sources folder according to each source."

--- a/investd/reports/__init__.py
+++ b/investd/reports/__init__.py
@@ -6,7 +6,7 @@ from nbconvert.exporters import HTMLExporter, export
 from nbconvert.preprocessors import ExecutePreprocessor
 
 from investd import config
-from investd.errors import NoTransactions
+from investd.exceptions import NoTransactions
 from investd.transaction import load_transactions
 
 

--- a/investd/reports/__init__.py
+++ b/investd/reports/__init__.py
@@ -5,11 +5,14 @@ import jupytext
 from nbconvert.exporters import HTMLExporter, export
 from nbconvert.preprocessors import ExecutePreprocessor
 
-from investd.config import INVESTD_REF_CURRENCY, INVESTD_REPORTS
+from investd import config
+from investd.errors import NoTransactions
+from investd.transaction import load_transactions
 
 
 def generate_report(notebook_name: str) -> Path:
     path_notebook = Path(__file__).parent / f"{notebook_name}.py"
+    _assert_transactions()
     notebook = jupytext.read(path_notebook)
     preprocessor = ExecutePreprocessor(timeout=10, kernel_name="python3")
     nb_executed, _ = preprocessor.preprocess(
@@ -32,8 +35,15 @@ def generate_report(notebook_name: str) -> Path:
 
 def _save_report(name: str, content: str) -> Path:
     today = datetime.today().strftime("%Y-%m-%d")
-    filename = f"{name}_{today}_{INVESTD_REF_CURRENCY}.html"
-    report_path = INVESTD_REPORTS / filename
+    filename = f"{name}_{today}_{config.INVESTD_REF_CURRENCY}.html"
+    report_path = config.INVESTD_REPORTS / filename
+    report_path.parent.mkdir(exist_ok=True, parents=True)
     with report_path.open("w") as out_file:
         out_file.write(content)
     return report_path
+
+
+def _assert_transactions() -> None:
+    df_tx = load_transactions()
+    if df_tx.empty:
+        raise NoTransactions()

--- a/investd/reports/overview.py
+++ b/investd/reports/overview.py
@@ -6,10 +6,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import seaborn as sns
-from IPython.display import Markdown, display
+from IPython.display import display
 
-from investd import views
-from investd.config import INVESTD_REF_CURRENCY
+from investd import config, views
 from investd.quotes import load_quotes
 from investd.transaction import load_transactions
 
@@ -29,7 +28,7 @@ report_date = (
 pd.DataFrame(
     {
         "Reporting date": [report_date],
-        "Reference currency": [INVESTD_REF_CURRENCY],
+        "Reference currency": [config.INVESTD_REF_CURRENCY],
         "Created date": [now.strftime("%Y-%m-%d")],
     },
     index=[""],
@@ -48,7 +47,7 @@ df_portfolio = views.portfolio_value(df_tx, df_quotes, at_date=report_date)
 # %%
 
 ref_amount_cols = [
-    col for col in df_portfolio.columns if str(INVESTD_REF_CURRENCY) in col
+    col for col in df_portfolio.columns if str(config.INVESTD_REF_CURRENCY) in col
 ]
 row_total = df_portfolio.loc[:, ref_amount_cols].sum(axis=0)
 row_total = pd.DataFrame(row_total, columns=["Total"]).transpose()
@@ -70,7 +69,7 @@ df_p_total.style.apply(highlight_total_row, axis=1).format(na_rep="", precision=
 df = views.invested_ref_amount_by_col(df_tx, "type")
 
 display(df)
-fig = df.plot.pie(y=str(INVESTD_REF_CURRENCY))
+fig = df.plot.pie(y=str(config.INVESTD_REF_CURRENCY))
 fig.get_legend().remove()
 
 # %% [markdown]
@@ -80,7 +79,7 @@ fig.get_legend().remove()
 df = views.amounts_by_currency(df_tx)
 
 display(df)
-fig = df.plot.pie(y=str(INVESTD_REF_CURRENCY))
+fig = df.plot.pie(y=str(config.INVESTD_REF_CURRENCY))
 fig.get_legend().remove()
 
 # %% [markdown]
@@ -99,6 +98,6 @@ fig, ax = plt.subplots()
 fig.autofmt_xdate()
 
 cumsum = df_tx["amount_ref_currency"].cumsum()
-df_cum = pd.DataFrame({INVESTD_REF_CURRENCY: cumsum, "Date": df_tx["timestamp"]})
+df_cum = pd.DataFrame({config.INVESTD_REF_CURRENCY: cumsum, "Date": df_tx["timestamp"]})
 
-fig = sns.lineplot(x="Date", y=INVESTD_REF_CURRENCY, data=df_cum, ax=ax)
+fig = sns.lineplot(x="Date", y=config.INVESTD_REF_CURRENCY, data=df_cum, ax=ax)

--- a/investd/sources/__init__.py
+++ b/investd/sources/__init__.py
@@ -1,12 +1,17 @@
+import logging
 from dataclasses import fields
 from itertools import chain
-from typing import Type
+from pathlib import Path
+from typing import Optional, Type
 
 import pandas as pd
 
+from investd import config
 from investd.sources import bonds, bossa, revolut_stocks, xtb
 from investd.sources.base import SourceBase
 from investd.transaction import Transaction
+
+log = logging.getLogger(__name__)
 
 sources: list[Type[SourceBase]] = [
     xtb.XTB,
@@ -23,3 +28,11 @@ def ingest_all() -> pd.DataFrame:
     )
     df_tx.sort_values(by="timestamp", ascending=True, inplace=True)
     return df_tx
+
+
+def ingest_to_path(path_output: Optional[Path] = None) -> None:
+    path_output = path_output or (config.INVESTD_PERSIST / "transactions.csv")
+    df_tx = ingest_all()
+    log.info(f"Writing {path_output}")
+    path_output.parent.mkdir(exist_ok=True, parents=True)
+    df_tx.to_csv(path_output, index=False)

--- a/investd/sources/base.py
+++ b/investd/sources/base.py
@@ -3,7 +3,7 @@ import logging
 from pathlib import Path
 from typing import Generator, Iterable
 
-from investd.config import INVESTD_SOURCES
+from investd import config
 from investd.transaction import Transaction
 
 log = logging.getLogger(__name__)
@@ -20,7 +20,7 @@ class SourceBase(metaclass=abc.ABCMeta):
         pass
 
     def load_transactions(self) -> Generator[Transaction, None, None]:
-        for path in (INVESTD_SOURCES / self.source_name).glob("*"):
+        for path in (config.INVESTD_SOURCES / self.source_name).glob("*"):
             log.info(f"Loading {path}")
             for tx in self.parse_source_file(path):
                 yield tx

--- a/investd/transaction.py
+++ b/investd/transaction.py
@@ -6,8 +6,8 @@ from typing import Any
 import pandas as pd
 from pydantic.dataclasses import dataclass
 
+from investd import config
 from investd.common import Action, AssetType, Currency
-from investd.config import INVESTD_PERSIST
 
 TX_FILENAME = "transactions.csv"
 
@@ -30,8 +30,12 @@ class Transaction:
 
 def load_transactions() -> pd.DataFrame:
     """Load transactions in persistence as a DataFrame."""
-    path = INVESTD_PERSIST / TX_FILENAME
-    df_tx = pd.read_csv(path, converters=_enum_fields(Transaction))
+    path = config.INVESTD_PERSIST / TX_FILENAME
+    df_tx = (
+        pd.read_csv(path, converters=_enum_fields(Transaction))
+        if path.exists()
+        else pd.DataFrame()
+    )
     schema = _to_pandas_schema(Transaction)
     return df_tx.astype(schema)
 

--- a/logging.yaml
+++ b/logging.yaml
@@ -1,5 +1,5 @@
 version: 1
-disable_existing_loggers: false
+disable_existing_loggers: true
 formatters:
   default:
     format: '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
@@ -16,7 +16,7 @@ loggers:
   app:
     handlers:
     - console
-    level: INFO
+    level: DEBUG
     propagate: false
 root:
   handlers:

--- a/logging.yaml
+++ b/logging.yaml
@@ -16,7 +16,7 @@ loggers:
   app:
     handlers:
     - console
-    level: DEBUG
+    level: INFO
     propagate: false
 root:
   handlers:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,8 @@ from typing import Generator
 import pandas as pd
 import pytest
 
+from investd import config
 from investd.common import Action, AssetType, Currency
-from investd.config import INVESTD_PERSIST, INVESTD_REPORTS, INVESTD_SOURCES
 from investd.quotes import QUOTES_FILENAME
 
 
@@ -16,35 +16,35 @@ def path_resources() -> Path:
 
 @pytest.fixture
 def setup_reports() -> Generator[None, None, None]:
-    INVESTD_REPORTS.mkdir(exist_ok=True)
+    config.INVESTD_REPORTS.mkdir(exist_ok=True)
     yield
-    for path in INVESTD_REPORTS.glob("*.html"):
+    for path in config.INVESTD_REPORTS.glob("*.html"):
         path.unlink()
 
 
 @pytest.fixture
 def path_revolut_csv() -> Path:
-    return INVESTD_SOURCES / "revolut_stocks/revolut-stocks-statement.csv"
+    return config.INVESTD_SOURCES / "revolut_stocks/revolut-stocks-statement.csv"
 
 
 @pytest.fixture
 def path_xtb_xlsx() -> Path:
-    return INVESTD_SOURCES / "xtb/xtb-statement.xlsx"
+    return config.INVESTD_SOURCES / "xtb/xtb-statement.xlsx"
 
 
 @pytest.fixture
 def path_xtb_csv() -> Path:
-    return INVESTD_SOURCES / "xtb/xtb-statement.csv"
+    return config.INVESTD_SOURCES / "xtb/xtb-statement.csv"
 
 
 @pytest.fixture
 def path_bonds_xls() -> Path:
-    return INVESTD_SOURCES / "bonds/bonds-statement.xls"
+    return config.INVESTD_SOURCES / "bonds/bonds-statement.xls"
 
 
 @pytest.fixture
 def path_bossa_csv() -> Path:
-    return INVESTD_SOURCES / "bossa/bossa-statement.csv"
+    return config.INVESTD_SOURCES / "bossa/bossa-statement.csv"
 
 
 @pytest.fixture
@@ -85,13 +85,13 @@ def df_quotes_minimal() -> pd.DataFrame:
 
 @pytest.fixture
 def df_quotes() -> pd.DataFrame:
-    return pd.read_csv(INVESTD_PERSIST / QUOTES_FILENAME, parse_dates=["date"])
+    return pd.read_csv(config.INVESTD_PERSIST / QUOTES_FILENAME, parse_dates=["date"])
 
 
 @pytest.fixture
 def yfinance_quotes() -> pd.DataFrame:
     df_quotes = pd.read_csv(
-        INVESTD_PERSIST / "yfinance_quotes.csv", header=[0, 1], index_col=0
+        config.INVESTD_PERSIST / "yfinance_quotes.csv", header=[0, 1], index_col=0
     )
     df_quotes.index = df_quotes.index.map(pd.to_datetime)
     return df_quotes

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+from pytest import MonkeyPatch
+
+import investd
+from investd.__main__ import cli
+from investd.errors import NoTransactions
+
+
+@pytest.fixture
+def empty_data_dir(monkeypatch: MonkeyPatch, tmp_path: Path) -> Path:
+    monkeypatch.setattr(investd.config, "INVESTD_DATA", tmp_path)
+    for conf in ["PERSIST", "SOURCES", "REPORTS"]:
+        monkeypatch.setattr(investd.config, f"INVESTD_{conf}", tmp_path / conf.lower())
+    return tmp_path
+
+
+def test_new_data_dir(empty_data_dir: Path) -> None:
+    result = CliRunner().invoke(cli, ["report"])
+    assert isinstance(result.exception, NoTransactions)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,7 @@ from pytest import MonkeyPatch
 
 import investd
 from investd.__main__ import cli
-from investd.errors import NoTransactions
+from investd.exceptions import NoTransactions
 
 
 @pytest.fixture

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,8 +1,8 @@
-from investd.config import INVESTD_REPORTS
+from investd import config
 from investd.reports import generate_report
 
 
 def test_generate_overview_report(setup_reports: None) -> None:
-    assert not list(INVESTD_REPORTS.glob("*.html"))
+    assert not list(config.INVESTD_REPORTS.glob("*.html"))
     report_path = generate_report("overview")
-    assert report_path in list(INVESTD_REPORTS.glob("*.html"))
+    assert report_path in list(config.INVESTD_REPORTS.glob("*.html"))


### PR DESCRIPTION
- Add an `error.py` module for expected errors.
- Add verification for non-empty transactions dataframe before generating report in `report.py`, raises a `NoTransactions` error if empty.
- Fix date error in `__main__` in the report command.
- Wraps cli call to only write what went wrong in stdout, logs the stack trace in the error log.
- Convert all references to config variables (INVESTD_DATA, INVESTD_SOURCES, etc) to be lazy import from `config` module.
- Test for empty data folder.
- Refactor ingest command to avoid repeated code.
- Check if quotes files exists before loading it. If not, loads and empty quotes data frame.

closes #58 