### PR TITLE
Filter dividends and fix XTB

### DIFF
--- a/investd/sources/revolut_stocks.py
+++ b/investd/sources/revolut_stocks.py
@@ -23,7 +23,9 @@ class RevolutStocks(SourceBase):
                 price = float(row["Price per share"].replace("$", "").replace(",", ""))
                 yield Transaction(
                     id="",
-                    timestamp=dateutil.parser.isoparse(row["Date"]),
+                    timestamp=dateutil.parser.isoparse(row["Date"]).replace(
+                        tzinfo=None
+                    ),
                     symbol=row["Ticker"],
                     type=AssetType.Stock,
                     platform=self.source_name,

--- a/investd/sources/xtb.py
+++ b/investd/sources/xtb.py
@@ -16,6 +16,7 @@ COL_TIME = "Time"
 COL_TYPE = "Type"
 
 INPUT_COLUMNS = [COL_AMOUNT, COL_COMMENT, COL_ID, COL_SYMBOL, COL_TIME, COL_TYPE]
+SUPPORTED_TYPES = {"Stocks/ETF purchase", "Stocks/ETF sale"}
 
 
 class XTB(SourceBase):
@@ -29,22 +30,27 @@ class XTB(SourceBase):
                 skiprows=10,
                 usecols=INPUT_COLUMNS,
                 parse_dates=[COL_TIME],
+                date_format="%d.%m.%Y %H:%M:%S",
             )
         elif path.suffix == ".csv":
             df = pd.read_csv(
-                path, usecols=INPUT_COLUMNS, parse_dates=[COL_TIME], sep=";"
+                path,
+                usecols=INPUT_COLUMNS,
+                sep=";",
+                parse_dates=[COL_TIME],
+                date_format="%d.%m.%Y %H:%M:%S",
             )
         else:
             return []
 
-        df = df[~pd.isna(df[COL_SYMBOL])]
+        df = df[pd.notna(df[COL_SYMBOL]) & df[COL_TYPE].isin(SUPPORTED_TYPES)]
         return map(lambda i_row: self._convert(i_row[1]), df.iterrows())
 
     def _convert(self, record: pd.Series) -> Transaction:
         action, quantity, price = XTB.parse_comment(record[COL_COMMENT])
         return Transaction(
             id=str(record[COL_ID]),
-            timestamp=record[COL_TIME],
+            timestamp=pd.to_datetime(record[COL_TIME]),
             symbol=record[COL_SYMBOL],
             type=AssetType.ETF,
             platform=self.source_name,

--- a/tests/resources/data/sources/xtb/xtb-statement.csv
+++ b/tests/resources/data/sources/xtb/xtb-statement.csv
@@ -5,3 +5,4 @@ ID;Type;Time;Symbol;Comment;Amount
 130658625;Deposit;08.12.2022 19:15:04;;Pekao S.A. deposit, Pekao S.A. provider transaction id=NL9S2567123361Z, Pekao S.A. merchant reference id=65165, id=1123;426.46
 120055884;Stocks/ETF purchase;09.11.2022 14:57:11;IBC5.DE;OPEN BUY 7 @ 5.0220;-35.15
 120045385;Stocks/ETF purchase;09.11.2022 14:37:19;SXR8.DE;OPEN BUY 1 @ 392.20;-392.2
+207157984;Dividend;29.12.2021 12:00:01;VHYD.UK;VHYD.UK USD 0.5074/ SHR;12.34

--- a/tests/sources/test_xtb.py
+++ b/tests/sources/test_xtb.py
@@ -36,7 +36,7 @@ def test_parse_xtb_csv(path_xtb_csv: Path) -> None:
     tx: Transaction = txs[0]
     assert tx.id == "130876160"
     assert tx.symbol == "IBC5.DE"
-    assert tx.timestamp == datetime(2022, 9, 12, 12, 9, 37)
+    assert tx.timestamp == datetime(2022, 12, 9, 12, 9, 37)
     assert tx.type == AssetType.ETF
     assert tx.platform == "xtb"
     assert tx.currency == Currency.EUR


### PR DESCRIPTION
- Dividend entries cause xtb ingestion to break.
- Fix the date parsing of xtb.